### PR TITLE
feat: adds duplicate weapon and sharpness buttons

### DIFF
--- a/WebToolkit/Pages/TreeGenerator.cshtml
+++ b/WebToolkit/Pages/TreeGenerator.cshtml
@@ -111,7 +111,7 @@
 								<div class="row">
 									<div class="col m-auto">
 										<div class="align-self-end float-end form-group">
-											<button type="button" onclick="addRow($(this).parents('.card-body').children().find('table.table-tree tbody'));" class="btn btn-primary" title="Add new row that represents a weapon in the tree.">Add New Weapon</button>
+											<button type="button" onclick="addEmptyRow($(this).parents('.card-body').children().find('table.table-tree tbody'));" class="btn btn-primary" title="Add new row that represents a weapon in the tree.">Add New Weapon</button>
 										</div>
 									</div>
 								</div>

--- a/WebToolkit/Pages/WeaponGenerator.cshtml
+++ b/WebToolkit/Pages/WeaponGenerator.cshtml
@@ -614,8 +614,11 @@
                 </div>
                 <hr />
                 <div class="row">
-                    <div class="col">
+                    <div class="col-6">
                         <h5>Second Bar</h5>
+                    </div>
+                    <div class="col-6" style="display: flex;justify-content: flex-end;">
+                        <button type="button" onclick="duplicateSharpness()" class="btn btn-primary" title="Duplicate first bar sharpness in the second bar."><i class="bi bi-copy"></i></button>
                     </div>
                 </div>
                 <div class="row">

--- a/WebToolkit/wwwroot/js/TreeGenerator.js
+++ b/WebToolkit/wwwroot/js/TreeGenerator.js
@@ -56,17 +56,30 @@ function loadTemplate()
             getFinalData = WeaponTemplate.getFinalData;
             pageLoadData = WeaponTemplate.pageLoadData;
             getSaveData = WeaponTemplate.getSaveData;
-            addRow($(".card .table-tree tbody"));
+            addEmptyRow($(".card .table-tree tbody"));
             break;
     }
     initTemplate();
 }
 
-function addRow(table)
+function addEmptyRow(table)
 {
-    $(table).append($(srcTreeRow).clone(true));
-    initRow();
-    updateIcons();
+    addRow(table, $(srcTreeRow).clone(true));
+}
+
+function addRow(table, row, index = -1) {
+    // Append in the end of the table
+    if (index == -1) {
+        $(table).append(row);
+        initRow();
+        updateIcons();
+    }
+    // Append at specified index
+    else {
+        $(table).find("tbody > tr").eq(index).after(row);
+        initRow();
+        updateIcons();
+    }
 }
 
 function collapseCard(button) {
@@ -91,4 +104,38 @@ function addTreeCard()
     $(el).find(".table-tree tbody").append($(srcTreeRow).clone(true));
     initRow();
     updateIcons();
+}
+
+function duplicateRow(row) {
+    
+    var duplicatedRow = $(srcTreeRow).clone(true);
+    var table = $(row).parent().parent();
+    addRow(table, duplicatedRow, row.index())
+
+    duplicatedRow.find("[data-label=can-rollback]").prop("checked", row.find("[data-label=can-rollback]").is(":checked"))
+
+    duplicatedRow.find("[data-label=parent]").val(row.find("[data-label=name]").val())
+
+    var icontype = row.find("[data-label=icon-type]").find(":selected").val()
+    if (icontype) {
+        duplicatedRow.find("[data-label=icon-type]").val(icontype).change()
+    }
+
+    var stats = row.find("[data-label=stats]").val()
+    if (stats) {
+        duplicatedRow.find("[data-label=stats]").val(stats)
+        duplicatedRow.find("[data-label=stats]").parent().find("button").addClass("btn-success")
+    }
+
+    var decos = row.find("[data-label=decos]").val()
+    if (decos) {
+        duplicatedRow.find("[data-label=decos]").val(decos)
+        duplicatedRow.find("[data-label=decos]").parent().find("button").addClass("btn-success")
+    }
+
+    var sharpness = row.find("[data-label=sharpness]").val()
+    if (sharpness) {
+        duplicatedRow.find("[data-label=sharpness]").val(sharpness)
+        duplicatedRow.find("[data-label=sharpness]").parent().find("button").addClass("btn-success")
+    }
 }

--- a/WebToolkit/wwwroot/js/WeaponGenerator.js
+++ b/WebToolkit/wwwroot/js/WeaponGenerator.js
@@ -81,6 +81,17 @@ function applySharpness() {
         return currentSharpnessCallback(currentSharpnessCallbackArgs[0], currentSharpnessCallbackArgs[1], currentSharpnessCallbackArgs[2]);
     }
 }
+function duplicateSharpness() {
+    $("#txtRedSharpnessHits2").val($("#txtRedSharpnessHits1").val());
+    $("#txtOrangeSharpnessHits2").val($("#txtOrangeSharpnessHits1").val());
+    $("#txtYellowSharpnessHits2").val($("#txtYellowSharpnessHits1").val());
+    $("#txtGreenSharpnessHits2").val($("#txtGreenSharpnessHits1").val());
+    $("#txtBlueSharpnessHits2").val($("#txtBlueSharpnessHits1").val());
+    $("#txtWhiteSharpnessHits2").val($("#txtWhiteSharpnessHits1").val());
+    $("#txtPurpleSharpnessHits2").val($("#txtPurpleSharpnessHits1").val());
+    updatePreviewBar("2");
+}
+
 function validateSharpness(value) {
     var valid = true;
     try {

--- a/WebToolkit/wwwroot/js/treeTemplates/weapon.js
+++ b/WebToolkit/wwwroot/js/treeTemplates/weapon.js
@@ -80,8 +80,11 @@ class WeaponTemplate
 						</div>
 						<hr/>
 						<div class="row">
-							<div class="col">
+							<div class="col-6">
 								<h5>Second Bar</h5>
+							</div>
+							<div class="col-6" style="display: flex;justify-content: flex-end;">
+								<button type="button" onclick="WeaponTemplate.duplicateSharpness()" class="btn btn-primary" title="Duplicate first bar sharpness in the second bar."><i class="bi bi-copy"></i></button>
 							</div>
 						</div>
 						<div class="row">
@@ -479,6 +482,16 @@ class WeaponTemplate
 		if (typeof (WeaponTemplate.currentSharpnessCallback) !== 'undefined') {
 			return WeaponTemplate.currentSharpnessCallback(WeaponTemplate.currentSharpnessCallbackArgs[0], WeaponTemplate.currentSharpnessCallbackArgs[1], WeaponTemplate.currentSharpnessCallbackArgs[2]);
 		}
+	}
+	static duplicateSharpness() {
+		$("#txtRedSharpnessHits2").val($("#txtRedSharpnessHits1").val());
+		$("#txtOrangeSharpnessHits2").val($("#txtOrangeSharpnessHits1").val());
+		$("#txtYellowSharpnessHits2").val($("#txtYellowSharpnessHits1").val());
+		$("#txtGreenSharpnessHits2").val($("#txtGreenSharpnessHits1").val());
+		$("#txtBlueSharpnessHits2").val($("#txtBlueSharpnessHits1").val());
+		$("#txtWhiteSharpnessHits2").val($("#txtWhiteSharpnessHits1").val());
+		$("#txtPurpleSharpnessHits2").val($("#txtPurpleSharpnessHits1").val());
+		WeaponTemplate.updatePreviewBar("2");
 	}
 	static applyStats() {
 		if (typeof (WeaponTemplate.currentStatsRow) !== 'undefined') {

--- a/WebToolkit/wwwroot/js/treeTemplates/weapon.js
+++ b/WebToolkit/wwwroot/js/treeTemplates/weapon.js
@@ -304,7 +304,7 @@ class WeaponTemplate
     <th scope="col" style="width:4rem;">Stats</th>
     <th scope="col" style="width:4rem;">Decos</th>
     <th scope="col" style="width:4rem;">Sharpness</th>
-    <th scope="col" style="width:0.375rem">Delete</th>
+    <th scope="col" style="width:0.375rem">Options</th>
 </tr>`;
     }
     static getRow()
@@ -360,6 +360,7 @@ class WeaponTemplate
 		<button class="btn btn-primary ignore-generate" type="button" onclick="WeaponTemplate.modifySharpness($(this).parent().parent(), validateComplexData, this, $(this).parent().children().first(), WeaponTemplate.validateSharpness);">Modify</button>
 	</td>
 	<td class="ignore-generate" style="text-align:center">
+		<button type="button" onclick="duplicateRow($(this).parent().parent())" class="btn btn-primary" title="Duplicate the weapon."><i class="bi bi-copy"></i></button>
 		<button type="button" onclick="$(this).parent().parent().remove();" class="btn btn-danger btn-delete-row" title="Delete this weapon."><i class="bi bi-trash"></i></button>
 	</td>
 </tr>`;


### PR DESCRIPTION
Adds a duplicate button in the Delete menu
Copies "Undo", precedent weapon name as "can be upgrade of" name, item type, rarity, stats, decos and sharpness
Renamed the Delete menu "Options" as it contains both Duplicate and Delete

Also adds a copy button in the sharpness menu to duplicate the first bar onto the second one