### PR TITLE
feat: being able to parse sharpness on csv format

### DIFF
--- a/WebToolkit/Controllers/WeaponTreeController.cs
+++ b/WebToolkit/Controllers/WeaponTreeController.cs
@@ -22,11 +22,11 @@ namespace WebToolkit.Controllers
 		}
 
         [HttpPost("ParseCsv")]
-        public string ParseCsv(string csvFile)
+        public string ParseCsv(string csvFile, bool duplicateSharpness)
         {
             try
             {
-                return MediawikiTranslator.Generators.WeaponTree.ParseCsv(csvFile);
+                return MediawikiTranslator.Generators.WeaponTree.ParseCsv(csvFile, duplicateSharpness);
             }
             catch (Exception ex)
             {

--- a/WebToolkit/Pages/TreeGenerator.cshtml
+++ b/WebToolkit/Pages/TreeGenerator.cshtml
@@ -41,6 +41,7 @@
 				url: '@(Url.Action("ParseCsv", "WeaponTree"))/',
 				data: {
 					csvFile: text,
+					duplicateSharpness: ($("#duplicateSharpnessCsv").is(":checked"))
 				},
 				type: "POST",
 				dataType: "text",
@@ -354,7 +355,15 @@
 				<div class="row">
 					<span>Delimiter must be ','</span>
 					<span>Format should be :</span>
-					<span>Name,Parent,Rarity,Attack,Affinity,Defense,Element_hidden_bool,Element1,ElementAttack1,Element2,ElementAttack2,Elderseal,Deco1,Deco2,Deco3</span>
+					<span style="font-size: 14px;">Name,Parent,Rarity,Attack,Affinity,Defense,Element_hidden_bool,Element1,ElementAttack1,Element2,ElementAttack2,Elderseal,Deco1,Deco2,Deco3,</span>
+					<span style="font-size: 14px;">RedSharpness1,OrangeSharpness1,YellowSharpness1,GreenSharpness1,BlueSharpness1,WhiteSharpness1,PurpleSharpness1,</span>
+					<span style="font-size: 14px;">RedSharpness2,OrangeSharpness2,YellowSharpness2,GreenSharpness2,BlueSharpness2,WhiteSharpness2,PurpleSharpness2</span>
+					<span>Sharpness can be fully omitted, or have sharpness 2 omitted, and can have sharpness2 be sharpness1 duplicated</span>
+					<div class="row" style="margin-top: 10px; margin-bottom:10px;">
+						<div class="col-6">
+							<input type="checkbox" id="duplicateSharpnessCsv" /> Duplicate sharpness data
+						</div>
+					</div>
 					<div class="row" style="margin-top: 10px; margin-bottom:10px;">
 						<div class="col-10">
 							<textarea class="form-control" type="file" id="inputCsvFile" rows="12"></textarea>

--- a/WebToolkit/wwwroot/js/TreeGenerator.js
+++ b/WebToolkit/wwwroot/js/TreeGenerator.js
@@ -169,6 +169,24 @@ function addRowFromCsv(weaponDict) {
     var decos = getDecos(parseInt(weaponDict["DecoSlot1"]), parseInt(weaponDict["DecoSlot2"]), parseInt(weaponDict["DecoSlot3"]));
     row.find("[data-label=decos]").val(decos);
     row.find("[data-label=decos]").parent().find("button").addClass("btn-success");
+
+    if (weaponDict["Sharpness1"]) {
+        var sharpness = [parseSharpnessCsv(weaponDict["Sharpness1"]), parseSharpnessCsv(weaponDict["Sharpness2"])];
+        row.find("[data-label=sharpness]").val(JSON.stringify(sharpness));
+        row.find("[data-label=sharpness]").parent().find("button").addClass("btn-success");
+    }
+}
+
+function parseSharpnessCsv(sharpnessData) {
+    return [
+        sharpnessData["Red"] ? sharpnessData["Red"].toString() : "0",
+        sharpnessData["Orange"] ? sharpnessData["Orange"].toString() : "0",
+        sharpnessData["Yellow"] ? sharpnessData["Yellow"].toString() : "0",
+        sharpnessData["Green"] ? sharpnessData["Green"].toString() : "0",
+        sharpnessData["Blue"] ? sharpnessData["Blue"].toString() : "0",
+        sharpnessData["White"] ? sharpnessData["White"].toString() : "0",
+        sharpnessData["Purple"] ? sharpnessData["Purple"].toString() : "0",
+    ]
 }
 
 function getDecos(levelSlot1, levelSlot2, levelSlot3) {


### PR DESCRIPTION
Include sharpness levels in the csv format parsing
Let the user duplicate sharpness1 in sharpness2 if it's omitted
Sharpness shouldn't be mandatory


https://github.com/user-attachments/assets/594fe567-f9a9-444a-96b6-6dc6816f9bf3

